### PR TITLE
Fix 'Chassis' object has no attribute 'get_num_psu' in test_psu.py

### DIFF
--- a/sonic-pde-tests/sonic_pde_tests/test_psu.py
+++ b/sonic-pde-tests/sonic_pde_tests/test_psu.py
@@ -21,11 +21,11 @@ def _wrapper_init():
        except Exception as e:
            print("Failed to load chassis due to {}".format(repr(e)))
 
-def _wrapper_get_num_psu():
+def _wrapper_get_num_psus():
     _wrapper_init()
     if platform_chassis is not None:
        try:
-           return platform_chassis.get_num_psu()
+           return platform_chassis.get_num_psus()
        except NotImplementedError:
            pass
 
@@ -140,7 +140,7 @@ def test_for_num_psus(json_config_data):
             }
         }
         """
-    assert _wrapper_get_num_psu() == json_config_data['PLATFORM']['num_psus'],"System plugin reports that {} psu are supported in platform".format(_wrapper_get_num_psu())
+    assert _wrapper_get_num_psus() == json_config_data['PLATFORM']['num_psus'],"System plugin reports that {} psu are supported in platform".format(_wrapper_get_num_psus())
 
 def test_for_psu_present(json_config_data, json_test_data):
     """Test Purpose:  Test Purpose: Verify that the PSUs that are present report as present in the PSU plugin.
@@ -191,7 +191,7 @@ def test_for_psu_notpresent(json_config_data, json_test_data):
        }
 
     """
-    num_psus = _wrapper_get_num_psu()
+    num_psus = _wrapper_get_num_psus()
     for key in json_config_data:
         for x in range (1, num_psus):
             if _wrapper_get_psu_presence(x-1) == True:


### PR DESCRIPTION
#### Why I did it
Fix 'Chassis' object has no attribute 'get_num_psu' in test_psu.py

#### How I did it
Update 'platform_chassis.get_num_psu()' to 'platform_chassis.get_num_psus()'

#### How to verify it

```
root@sonic:~# pde-test -v test_psu.py
==================================================================== test session starts ====================================================================
platform linux -- Python 3.9.2, pytest-7.4.4, pluggy-1.3.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /usr/local/sonic_pde_tests
collected 13 items                                                                                                                                          

test_psu.py::test_for_num_psus PASSED                                                                                                                 [  7%]
test_psu.py::test_for_psu_present PASSED                                                                                                              [ 15%]
test_psu.py::test_for_psu_notpresent PASSED                                                                                                           [ 23%]
test_psu.py::test_for_psu_status PASSED                                                                                                               [ 30%]
test_psu.py::test_for_psu_serial_num PASSED                                                                                                           [ 38%]
test_psu.py::test_for_psu_model PASSED                                                                                                                [ 46%]
test_psu.py::test_for_psu_voltage PASSED                                                                                                              [ 53%]
test_psu.py::test_for_psu_current PASSED                                                                                                              [ 61%]
test_psu.py::test_for_psu_power PASSED                                                                                                                [ 69%]
test_psu.py::test_for_psu_input_voltage PASSED                                                                                                        [ 76%]
test_psu.py::test_for_psu_input_current PASSED                                                                                                        [ 84%]
test_psu.py::test_for_psu_capacity PASSED                                                                                                             [ 92%]
test_psu.py::test_for_psu_type PASSED                                                                                                                 [100%]

===================================================================== warnings summary ======================================================================
test_psu.py:3
  /usr/local/sonic_pde_tests/test_psu.py:3: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 13 passed, 1 warning in 1.37s ===============================================================
```

